### PR TITLE
chore: migrate pnpm from v10 to v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,0 @@
-public-hoist-pattern[]=*@heroui/*
-public-hoist-pattern[]=*eslint*
-public-hoist-pattern[]=*prettier*
-engine-strict=true
-package-manager-strict-version=false
-manage-package-manager-versions=true

--- a/next.config.ts
+++ b/next.config.ts
@@ -134,4 +134,6 @@ export default withSentryConfig(withPWA(nextConfig), {
       removeDebugLogging: true,
     },
   },
+
+  telemetry: false,
 })

--- a/package.json
+++ b/package.json
@@ -162,17 +162,5 @@
   "engines": {
     "node": "22.x"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@heroui/shared-utils",
-      "@sentry/cli",
-      "@vercel/speed-insights",
-      "bcrypt",
-      "esbuild",
-      "oxc-resolver",
-      "sharp",
-      "unrs-resolver"
-    ]
-  },
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@11.8.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,15 @@
+publicHoistPattern:
+  - '*@heroui/*'
+  - '*eslint*'
+  - '*prettier*'
+engineStrict: true
+allowBuilds:
+  '@heroui/shared-utils': true
+  '@sentry/cli': true
+  '@vercel/speed-insights': true
+  bcrypt: true
+  esbuild: true
+  oxc-resolver: true
+  sharp: true
+  unrs-resolver: true
+pmOnFail: download


### PR DESCRIPTION
and disable Sentry telemetry